### PR TITLE
Fixed a typo in code block

### DIFF
--- a/6.2/gridftp/GridFTP_Interface_Config_Client_Firewall_Frag.adoc
+++ b/6.2/gridftp/GridFTP_Interface_Config_Client_Firewall_Frag.adoc
@@ -20,7 +20,7 @@ opened a range of (local) ports, set the environment variable
 GLOBUS_TCP_SOURCE_RANGE: 
 +
 --------
-export GLOBUS_TCP_PORT_RANGE=min,max 
+export GLOBUS_TCP_SOURCE_RANGE=min,max 
 --------
 +
 where min,max specify the port range that you have opened for the


### PR DESCRIPTION
Fixed a typo in code block that mismatched the variable name described in the doc above.